### PR TITLE
Implemented not found error

### DIFF
--- a/src/errors/notfound.error.js
+++ b/src/errors/notfound.error.js
@@ -1,0 +1,15 @@
+const BaseError = require("./base.error");
+const { StatusCodes } = require("http-status-codes");
+
+class NotFound extends BaseError {
+  constructor(details) {
+    super(
+      "NotFound",
+      StatusCodes.NOT_FOUND,
+      "The requested resource was not found.",
+      details
+    );
+  }
+}
+
+module.exports = NotFound;

--- a/src/index.js
+++ b/src/index.js
@@ -3,7 +3,8 @@ const bodyParser = require('body-parser');
 
 const { PORT } = require('./config/server.config');
 const apiRouter = require('./routes');
-const errorHandler = require('./utils/errorHandler');
+const { errorHandler, notFound } = require('./utils/errorHandler');
+
 
 
 const app = express();
@@ -21,6 +22,8 @@ app.get('/ping', (req, res) => {
     return res.json({message: 'Problem Service is alive'});
 });
 
+// this will throw an NotFound error if you hit any route which is not defined
+app.use(notFound);
 // last middleware if any error comes
 app.use(errorHandler);
 

--- a/src/utils/errorHandler.js
+++ b/src/utils/errorHandler.js
@@ -1,6 +1,8 @@
 const BaseError = require("../errors/base.error");
 const { StatusCodes } = require('http-status-codes');
-function errorHandler(err, req, res) {
+const NotFound = require("../errors/notfound.error");
+
+function errorHandler(err, req, res, next) {
     if(err instanceof BaseError) {
         return res.status(err.statusCode).json({
             success: false,
@@ -18,4 +20,11 @@ function errorHandler(err, req, res) {
     });
 }
 
-module.exports = errorHandler;
+// this will throw an NotFound error if you hit any route which is not defined
+const notFound = (req, res, next) => {
+    const error = new NotFound(`Not Found - ${req.originalUrl}`);
+    res.status(StatusCodes.NOT_FOUND);
+    next(error);
+};
+
+module.exports = {errorHandler, notFound};


### PR DESCRIPTION
### If you Lets suppose hit a route that is not defined like `/api/v1/problems/ramdom` the default error hander of express will kick in 
![image](https://github.com/singhsanket143/AlgoCode-Problem-Service/assets/78687135/e01a9f1c-ab18-4449-bf37-59b56e278e5a)

### To handle that also I have made this pr and the result will be like this
![image](https://github.com/singhsanket143/AlgoCode-Problem-Service/assets/78687135/a53edde2-5451-4159-94f8-ae109bce58f7)