### PR TITLE
fix: Added config to save stack trace to the file

### DIFF
--- a/src/config/logger.config.js
+++ b/src/config/logger.config.js
@@ -1,44 +1,58 @@
-const winston = require('winston');
-const { LOG_DB_URL } = require('./server.config');
-require('winston-mongodb');
+const winston = require("winston");
+const { LOG_DB_URL } = require("./server.config");
+require("winston-mongodb");
 
 const allowedTransports = [];
 
 // The below transport configuration enables logging on the console
-allowedTransports.push(new winston.transports.Console({
+allowedTransports.push(
+  new winston.transports.Console({
     format: winston.format.combine(
-        winston.format.colorize(),
-        winston.format.timestamp({
-            format: 'YYYY-MM-DD HH:mm:ss'
-        }),
-        // Second argument to the combine method, which defines what is exactly going to be printed in log
-        winston.format.printf((log) => `${log.timestamp} [${log.level}]: ${log.message}`)
-    )
-}));
+      winston.format.colorize(),
+      winston.format.timestamp({
+        format: "YYYY-MM-DD HH:mm:ss",
+      }),
+      // Second argument to the combine method, which defines what is exactly going to be printed in log
+      winston.format.printf(
+        (log) => `${log.timestamp} [${log.level}]: ${log.message}`
+      )
+    ),
+  })
+);
 
 // The below transport configuration enables logging in mongodb database
-allowedTransports.push(new winston.transports.MongoDB({
-    level: 'error',
+allowedTransports.push(
+  new winston.transports.MongoDB({
+    level: "error",
     db: LOG_DB_URL,
-    collection: 'logs',
-}))
+    collection: "logs",
+  })
+);
 // The below transport configuration enables logging in mongodb database
-allowedTransports.push(new winston.transports.File({
-    filename: `app.log`
-}))
+allowedTransports.push(
+  new winston.transports.File({
+    filename: `app.log`,
+  })
+);
 
 const logger = winston.createLogger({
-    // default formatting
+  // default formatting
 
-    format: winston.format.combine(
-        // First argument to the combine method is defining how we want the timestamp to come up
-        winston.format.timestamp({
-            format: 'YYYY-MM-DD HH:mm:ss'
-        }),
-        // Second argument to the combine method, which defines what is exactly going to be printed in log
-        winston.format.printf((log) => `${log.timestamp} [${log.level.toUpperCase()}]: ${log.message}`)
-    ),
-    transports: allowedTransports
+  format: winston.format.combine(
+    // First argument to the combine method is defining how we want the timestamp to come up
+    winston.format.errors({ stack: true }),
+    winston.format.timestamp({
+      format: "YYYY-MM-DD HH:mm:ss",
+    }),
+    // Second argument to the combine method, which defines what is exactly going to be printed in log
+    winston.format.printf((log) => {
+      const text = `${log.timestamp} [${log.level.toUpperCase()}]: ${
+        log.message
+      }`;
+      return log.stack ? text + "\n" + log.stack : text;
+    })
+  ),
+  transports: allowedTransports,
 });
 
 module.exports = logger;

--- a/src/repositories/problem.repository.js
+++ b/src/repositories/problem.repository.js
@@ -1,62 +1,61 @@
-const logger = require('../config/logger.config');
-const NotFound = require('../errors/notfound.error');
-const { Problem } = require('../models');
+const logger = require("../config/logger.config");
+const NotFound = require("../errors/notfound.error");
+const { Problem } = require("../models");
 
 class ProblemRepository {
+  async createProblem(problemData) {
+    try {
+      const problem = await Problem.create({
+        title: problemData.title,
+        description: problemData.description,
+        testCases: problemData.testCases ? problemData.testCases : [],
+      });
 
-    async createProblem(problemData) {
-        try {
-
-            const problem = await Problem.create({
-                title: problemData.title,
-                description: problemData.description,
-                testCases: (problemData.testCases) ? problemData.testCases : []
-            });
-
-            return problem;
-        } catch(error) {
-            console.log(error);
-            throw error;
-        }
+      return problem;
+    } catch (error) {
+      console.log(error);
+      throw error;
     }
+  }
 
-    async getAllProblems() {
-        try {
-            const problems = await Problem.find({});
-            return problems;
-        } catch(error) {
-            console.log(error);
-            throw error;
-        }
+  async getAllProblems() {
+    try {
+      const problems = await Problem.find({});
+      return problems;
+    } catch (error) {
+      console.log(error);
+      throw error;
     }
+  }
 
-    async getProblem(id) {
-        try {
-            const problem = await Problem.findById(id);
-            if(!problem) {
-                throw new NotFound("Problem", id);
-            }
-            return problem;
-        } catch (error) {
-            console.log(error);
-            throw error;
-        }
-    } 
-
-    async deleteProblem(id) {
-        try {
-            const deletedProblem = await Problem.findByIdAndDelete(id);
-            if(!deletedProblem) {
-                logger.error(`Problem.Repository: Problem with id: ${id} not found in the db`);
-                throw new NotFound("problem", id);
-            }
-            return deletedProblem;
-        } catch (error) {
-            console.log(error);
-            throw error;
-        }
+  async getProblem(id) {
+    try {
+      const problem = await Problem.findById(id);
+      if (!problem) {
+        throw new NotFound("Problem", id);
+      }
+      return problem;
+    } catch (error) {
+      console.log(error);
+      throw error;
     }
+  }
 
+  async deleteProblem(id) {
+    try {
+      const deletedProblem = await Problem.findByIdAndDelete(id);
+      if (!deletedProblem) {
+        throw new NotFound("problem", id);
+      }
+      return deletedProblem;
+    } catch (error) {
+      logger.error(
+        `Problem.Repository: Problem with id: ${id} not found in the db`,
+        error
+      ); // Getting stack-trace works only with Error objects which have Error.stack property:
+      throw error;
+    }
+  }
 }
 
 module.exports = ProblemRepository;


### PR DESCRIPTION
If the error object is passed in the ```logger.error(msg, errorObj)```  along with the msg then it will also be saved in the log file else only the message will be saved.
<img width="1233" alt="Screenshot 2024-04-19 at 2 49 30 PM" src="https://github.com/singhsanket143/AlgoCode-Problem-Service/assets/76097072/77fe332d-76db-4edd-844d-3deb7acafa71">
