### PR TITLE
Fix : Added more strict check for invalid mongoDB ID

### DIFF
--- a/src/repositories/problem.repository.js
+++ b/src/repositories/problem.repository.js
@@ -1,3 +1,4 @@
+const logger = require('../config/logger.config');
 const NotFound = require('../errors/notfound.error');
 const { Problem } = require('../models');
 const {mongoose} = require('mongoose');
@@ -40,6 +41,20 @@ class ProblemRepository {
                 throw new NotFound("Problem", id);
             }
             return problem;
+        } catch (error) {
+            console.log(error);
+            throw error;
+        }
+    } 
+
+    async deleteProblem(id) {
+        try {
+            const deletedProblem = await Problem.findByIdAndDelete(id);
+            if(!deletedProblem) {
+                logger.error(`Problem.Repository: Problem with id: ${id} not found in the db`);
+                throw new NotFound("problem", id);
+            }
+            return deletedProblem;
         } catch (error) {
             console.log(error);
             throw error;

--- a/src/repositories/problem.repository.js
+++ b/src/repositories/problem.repository.js
@@ -1,7 +1,6 @@
-const logger = require('../config/logger.config');
 const NotFound = require('../errors/notfound.error');
 const { Problem } = require('../models');
-
+const {mongoose} = require('mongoose');
 class ProblemRepository {
 
     async createProblem(problemData) {
@@ -32,25 +31,15 @@ class ProblemRepository {
 
     async getProblem(id) {
         try {
+            const valid = mongoose.isValidObjectId(id)
+            if(!valid){
+                throw new NotFound("Problem", id);
+            }
             const problem = await Problem.findById(id);
             if(!problem) {
                 throw new NotFound("Problem", id);
             }
             return problem;
-        } catch (error) {
-            console.log(error);
-            throw error;
-        }
-    } 
-
-    async deleteProblem(id) {
-        try {
-            const deletedProblem = await Problem.findByIdAndDelete(id);
-            if(!deletedProblem) {
-                logger.error(`Problem.Repository: Problem with id: ${id} not found in the db`);
-                throw new NotFound("problem", id);
-            }
-            return deletedProblem;
         } catch (error) {
             console.log(error);
             throw error;


### PR DESCRIPTION
A valid mongo DB ID is a **24 character hexadecimal string value,** earlier if an ID string of length less then 24 chars size was passed in Params the errors was not handled properly.


![image](https://github.com/singhsanket143/AlgoCode-Problem-Service/assets/78806052/277e1b70-104d-473f-ba3b-395e28b1167e)

This can be seen here in above image, we are also making a DB call with invalid ID input, thus I have added an extra check for a valid ID input. 
