### PR TITLE
Fix : Added more strict check for invalid mongoDB ID

### DIFF
--- a/src/repositories/problem.repository.js
+++ b/src/repositories/problem.repository.js
@@ -1,6 +1,7 @@
 const logger = require('../config/logger.config');
 const NotFound = require('../errors/notfound.error');
 const { Problem } = require('../models');
+const {mongoose} = require('mongoose');
 
 class ProblemRepository {
 
@@ -32,6 +33,11 @@ class ProblemRepository {
 
     async getProblem(id) {
         try {
+            const valid = mongoose.isValidObjectId(id)
+            if(!valid){
+                logger.error(`Problem.Repository: Problem id: ${id} is not valid`);
+                throw new NotFound("Problem", id);
+            }
             const problem = await Problem.findById(id);
             if(!problem) {
                 throw new NotFound("Problem", id);
@@ -45,6 +51,11 @@ class ProblemRepository {
 
     async deleteProblem(id) {
         try {
+            const valid = mongoose.isValidObjectId(id)
+            if(!valid){
+                logger.error(`Problem.Repository: Problem id: ${id} is not valid`);
+                throw new NotFound("Problem", id);
+            }
             const deletedProblem = await Problem.findByIdAndDelete(id);
             if(!deletedProblem) {
                 logger.error(`Problem.Repository: Problem with id: ${id} not found in the db`);


### PR DESCRIPTION
A valid mongo DB ID is a 24 character hexadecimal string value, earlier if an ID string of length less then 24 chars size was passed in Params the errors was not handled properly.

![image](https://github.com/singhsanket143/AlgoCode-Problem-Service/assets/78806052/c33ee2d9-9ebd-482c-acf6-a114adbbf66f)

This can be seen here in above image, we are also making a DB call with invalid ID input, thus I have added an extra check for a valid ID input.

